### PR TITLE
Fix container push script to err on fail

### DIFF
--- a/build-and-push-versioned-container.sh
+++ b/build-and-push-versioned-container.sh
@@ -12,12 +12,16 @@ helptext() {
     exit 1
 }
 
+errExit() {
+    cleanup
+    exit 2
+}
+
 cleanup
 [[ -z $VERSION ]] && helptext
 [[ -z $IMAGE_PATH ]] && helptext
 
-
 sed "s/{version}/${VERSION}/g" Dockerfile.add-frontend-versions > Dockerfile.add-frontend-versions-${VERSION}
-docker build -t ${IMAGE_PATH}:${VERSION} -f Dockerfile.add-frontend-versions-${VERSION} .
-docker push ${IMAGE_PATH}:${VERSION}
+docker build -t ${IMAGE_PATH}:${VERSION} -f Dockerfile.add-frontend-versions-${VERSION} . || errExit
+docker push ${IMAGE_PATH}:${VERSION} || errExit
 cleanup


### PR DESCRIPTION
If a container fails to build or push during `make release-container-agent-multiversions`, it does not fail the `make`. This change should reflect that failure.

Signed-off-by: Brandon Lum <lumjjb@gmail.com>